### PR TITLE
Option to Disable SSH and remove secret for postgres if postgres is not deployed

### DIFF
--- a/gogs/Chart.yaml
+++ b/gogs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: 'Gogs: Go Git Service'
 name: gogs
-version: 0.9.2
+version: 0.9.3
 appVersion: 0.12.3
 home: https://gogs.io/
 icon: https://gogs.io/img/favicon.ico

--- a/gogs/templates/configmap.yaml
+++ b/gogs/templates/configmap.yaml
@@ -27,6 +27,7 @@ data:
     SSH_DOMAIN = {{ default .Values.service.gogs.serverDomain .Values.service.sshDomain }}
     SSH_PORT = {{ .Values.service.sshPort }}
     SSH_LISTEN_PORT = {{ .Values.service.sshPort }}
+    DISABLE_SSH = {{ .Values.service.disableSsh }}
 
     [service]
     ENABLE_CAPTCHA = {{ .Values.service.gogs.serviceEnableCaptcha }}

--- a/gogs/templates/deployment.yaml
+++ b/gogs/templates/deployment.yaml
@@ -38,7 +38,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: 3000
+            {{- if not .Values.service.disableSsh }}
             - containerPort: 22
+            {{- end }}
           livenessProbe:
             initialDelaySeconds: 15
             httpGet:

--- a/gogs/templates/secrets.yaml
+++ b/gogs/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgresql.install }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +11,4 @@ metadata:
 type: Opaque
 data:
   postgresql-user: {{ .Values.postgresql.postgresqlUsername | b64enc | quote }}
+{{- end }}

--- a/gogs/templates/service.yaml
+++ b/gogs/templates/service.yaml
@@ -20,11 +20,13 @@ spec:
     nodePort: {{ .Values.service.httpNodePort | int }}
 {{- end }}
     name: {{ default "gogs" .Values.service.nameOverride }}-http
+{{- if not .Values.service.disableSsh }}
   - port: {{ .Values.service.sshPort | int }}
     targetPort: 22
 {{- if (and (eq .Values.serviceType "NodePort") (not (empty .Values.service.sshNodePort))) }}
     nodePort: {{ .Values.service.sshNodePort | int }}
 {{- end }}
     name: {{ default "gogs" .Values.service.nameOverride }}-ssh
+{{- end }}
   selector:
     app: {{ template "gogs.fullname" . }}

--- a/gogs/values.yaml
+++ b/gogs/values.yaml
@@ -39,6 +39,10 @@ service:
   ##
   sshDomain: localhost
 
+  ## DISABLE_SSH - Whether to disable SSH access to the application entirely.
+  ##
+  disableSsh: false
+
   ## Gogs configuration values
   ##
   gogs:


### PR DESCRIPTION
Hi

Thanks for this helm chart! I've recently used it, and tweaked it a little to fit my needs, and I thought these tweaks could be merged back if you feel so.

It adds the DISABLE_SSH option into the config file, and only deploys the secret for postgresql if it is also deployed. In my setup we don't need it, so there is no need for it.